### PR TITLE
added support for 96x16 (8.4") OLED display

### DIFF
--- a/Adafruit_SSD1306/SSD1306.py
+++ b/Adafruit_SSD1306/SSD1306.py
@@ -305,3 +305,44 @@ class SSD1306_128_32(SSD1306Base):
 		self.command(0x40)
 		self.command(SSD1306_DISPLAYALLON_RESUME)           # 0xA4
 		self.command(SSD1306_NORMALDISPLAY)                 # 0xA6
+
+
+class SSD1306_96_16(SSD1306Base):
+	def __init__(self, rst, dc=None, sclk=None, din=None, cs=None, gpio=None,
+			spi=None, i2c_bus=I2C.get_default_bus(), i2c_address=SSD1306_I2C_ADDRESS):
+		# Call base class constructor.
+		super(SSD1306_96_16, self).__init__(96, 16, rst, dc, sclk, din, cs,
+										 gpio, spi, i2c_bus, i2c_address)
+
+	def _initialize(self):
+		# 128x32 pixel specific initialization.
+		self.command(SSD1306_DISPLAYOFF)                    # 0xAE
+		self.command(SSD1306_SETDISPLAYCLOCKDIV)            # 0xD5
+		self.command(0x60)                                  # the suggested ratio 0x60
+		self.command(SSD1306_SETMULTIPLEX)                  # 0xA8
+		self.command(0x0F)
+		self.command(SSD1306_SETDISPLAYOFFSET)              # 0xD3
+		self.command(0x0)                                   # no offset
+		self.command(SSD1306_SETSTARTLINE | 0x0)            # line #0
+		self.command(SSD1306_CHARGEPUMP)                    # 0x8D
+		if self._vccstate == SSD1306_EXTERNALVCC:
+			self.command(0x10)
+		else:
+			self.command(0x14)
+		self.command(SSD1306_MEMORYMODE)                    # 0x20
+		self.command(0x00)                                  # 0x0 act like ks0108
+		self.command(SSD1306_SEGREMAP | 0x1)
+		self.command(SSD1306_COMSCANDEC)
+		self.command(SSD1306_SETCOMPINS)                    # 0xDA
+		self.command(0x02)
+		self.command(SSD1306_SETCONTRAST)                   # 0x81
+		self.command(0x8F)
+		self.command(SSD1306_SETPRECHARGE)                  # 0xd9
+		if self._vccstate == SSD1306_EXTERNALVCC:
+			self.command(0x22)
+		else:
+			self.command(0xF1)
+		self.command(SSD1306_SETVCOMDETECT)                 # 0xDB
+		self.command(0x40)
+		self.command(SSD1306_DISPLAYALLON_RESUME)           # 0xA4
+		self.command(SSD1306_NORMALDISPLAY)                 # 0xA6


### PR DESCRIPTION
Hey guys, here is my code for the 96x16 class. It works fine with the shape.py example.
Not sure about line #L337-339 because there is some difference between class SSD1306_128_64 and SSD1306_128_32 at this point and I don't understand what it is good for. So I just copied the 128_32 version.
