### PR TITLE
Support python3 and while maintaining support for python 2.6+

### DIFF
--- a/Adafruit_SSD1306/SSD1306.py
+++ b/Adafruit_SSD1306/SSD1306.py
@@ -18,6 +18,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+
+from __future__ import division, absolute_import
+
 import logging
 import time
 
@@ -76,8 +79,8 @@ class SSD1306Base(object):
 		self._i2c = None
 		self.width = width
 		self.height = height
-		self._pages = height/8
-		self._buffer = [0]*(width*self._pages)
+		self._pages = int(height/8)
+		self._buffer = [0] * int(width * self._pages)
 		# Default to platform GPIO if not provided.
 		self._gpio = gpio
 		if self._gpio is None:

--- a/Adafruit_SSD1306/__init__.py
+++ b/Adafruit_SSD1306/__init__.py
@@ -1,1 +1,3 @@
-from SSD1306 import *
+from __future__ import absolute_import
+
+from Adafruit_SSD1306.SSD1306 import *


### PR DESCRIPTION
Provided the latest Adafruit_GPIO library is available and the python3-smbus package has been installed
this patch fixes the SSD1306 support when using python3 by handling the new absolute package naming
and dealing with the new division semantics.

Signed-off-by: Pat Thoyts <patthoyts@users.sourceforge.net>