### PR TITLE
Make it optional to use the RST pin

### DIFF
--- a/Adafruit_SSD1306/SSD1306.py
+++ b/Adafruit_SSD1306/SSD1306.py
@@ -85,7 +85,8 @@ class SSD1306Base(object):
             self._gpio = GPIO.get_platform_gpio()
         # Setup reset pin.
         self._rst = rst
-        self._gpio.setup(self._rst, GPIO.OUT)
+        if not self._rst is None:
+            self._gpio.setup(self._rst, GPIO.OUT)
         # Handle hardware SPI
         if spi is not None:
             self._log.debug('Using hardware SPI')
@@ -150,6 +151,8 @@ class SSD1306Base(object):
 
     def reset(self):
         """Reset the display."""
+        if self._rst is None:
+            return
         # Set reset high for a millisecond.
         self._gpio.set_high(self._rst)
         time.sleep(0.001)


### PR DESCRIPTION
Minor change to SSD1306.py to allow specifying None for the reset pin. This allows using the SSD1306 python code without root permissions by adding the user to the i2c group (e.g.: adduser pi i2c).
