### PR TITLE
Optimize update by sending only changed pages

### DIFF
--- a/Adafruit_SSD1306/SSD1306.py
+++ b/Adafruit_SSD1306/SSD1306.py
@@ -173,8 +173,8 @@ class SSD1306Base(object):
         if not self._bb[1] < self._bb[3]: # No pages
             return
         if (self._bb[2]-self._bb[0]) % 16 != 0:
-            self._bb[0] = self._bb[0] - (self._bb[0] % 16)
-            self._bb[2] = self._bb[2] - (self._bb[2] % 16) + 16  ## FIXME Boundary check
+            self._bb[0] = (self._bb[0] // 16) * 16
+            self._bb[2] = ( (self._bb[2]+15) // 16) * 16
         self.command(SSD1306_COLUMNADDR)
         self.command(self._bb[0])     # Column start address. (0 = reset)
         self.command(self._bb[2]-1)   # Column end address.
@@ -225,9 +225,9 @@ class SSD1306Base(object):
                 if self._buffer[index] != bits:
                     self._buffer[index] = bits
                     self._bb[0] = min(x, self._bb[0])
-                    self._bb[2] = max(x, self._bb[2])
+                    self._bb[2] = max(x+1, self._bb[2])
                     self._bb[1] = min(page, self._bb[1])
-                    self._bb[3] = max(page, self._bb[3])
+                    self._bb[3] = max(page+1, self._bb[3])
                 index += 1
 
     def clear(self):


### PR DESCRIPTION
Keep track of the bounding box of changed pixels. First `.display()` call will send all pixels, all subsequent `.display()` calls will only send pixels _changed_ during calls to `.image()`.

For most display operations this significantly increases the frame rate (on I2C at least) by reducing the number of bytes that need to be transmitted.

A new optional parameter `.display(force=True)` can be used to force full transmission of all pixels.

Limitations:
  * I2C updates send everything in multiples of 16 bytes. To ensure that an integer multiple of 16 bytes is sent, the bounding box column addresses are rounded up and down to be divisible by 16. This is theoretically not necessary for SPI operation, and may be optimized further.
  * SPI operation has not been tested
