### PR TITLE
320% faster refresh rate on I2C

### DIFF
--- a/Adafruit_SSD1306/SSD1306.py
+++ b/Adafruit_SSD1306/SSD1306.py
@@ -177,9 +177,8 @@ class SSD1306Base(object):
             # Write buffer.
             self._spi.write(self._buffer)
         else:
-            for i in range(0, len(self._buffer), 16):
-                control = 0x40   # Co = 0, DC = 0
-                self._i2c.writeList(control, self._buffer[i:i+16])
+            control = 0x40   # Co = 0, DC = 0
+            self._i2c.writeList(control, self._buffer)
 
     def image(self, image):
         """Set buffer to value of Python Imaging Library image.  The image should


### PR DESCRIPTION
![before after image](https://user-images.githubusercontent.com/837/40269624-001115cc-5b4f-11e8-9edc-50ba42e93b29.png)

The previous code broke up sending the data to the display into 16 byte chunks. Each packet takes a while to prepare, and incurs some overhead on the wire. During most of the screen update time, no actual data is being sent.

I'm guessing that these were broken into 1 control byte + 16 data bytes to fit into the 32 byte limit of smbus. However, the Adafruit_GPIO.I2C library talks to Linux I2C directly, does not use smbus and has no length restriction. Sending the entire display pixels in one I2C packet rather than separate connections for each 16 bytes gives me a 3x faster update time.

Tested on a Raspberry Pi Zero W with a [128x64 OLED bonnet](https://learn.adafruit.com/adafruit-128x64-oled-bonnet-for-raspberry-pi/overview)

Not tested on Beagle Bone Black.